### PR TITLE
Fixin main file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "string2stream",
   "version": "0.0.2",
   "description": "Converts a string into a stream",
+  "main": "string2stream",
   "scripts": {
     "test": " make test"
   },

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 var should = require('should')
-var string2stream = require('../string2stream')
+var string2stream = require('..')
 var fs = require('fs')
 var Stream = require('stream')
 


### PR DESCRIPTION
Weidmanns Heil!

`require('string2stream')` from other modules currently fails since the package doesn't indicate what the main file is.
I reproduced it by changing tests slightly and fixed it as well.
